### PR TITLE
Allow building a `Connection` with a hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,18 +4,18 @@ It's-a hella-redis!
 
 ## Usage
 
-### RedisConnection
+### Connection
 
 ```ruby
 # config and create a connection
-@config = OpenStruct.new({
+@config = {
   :timeout  => 1,
   :size     => 5,
   :redis_ns => 'hella-redis-test',
   :driver   => 'ruby',
   :url      => 'redis://localhost:6379/0'
-})
-@conn = HellaRedis::RedisConnection.new(@config)
+}
+@conn = HellaRedis::Connection.new(@config)
 
 # it's actually a pool of connections
 @conn.with do |conn|

--- a/lib/hella-redis/connection.rb
+++ b/lib/hella-redis/connection.rb
@@ -7,6 +7,7 @@ module HellaRedis
   module Connection
 
     def self.new(config)
+      config = Config.new(config) if config.kind_of?(::Hash)
       ::ConnectionPool.new(:timeout => config.timeout, :size => config.size) do
         ::Redis::Namespace.new(config.redis_ns, {
           :redis => ::Redis.connect({
@@ -14,6 +15,18 @@ module HellaRedis
             :driver => config.driver
           })
         })
+      end
+    end
+
+    class Config
+      attr_reader :url, :driver, :redis_ns, :timeout, :size
+
+      def initialize(args)
+        @url      = args[:url]
+        @driver   = args[:driver]
+        @redis_ns = args[:ns]
+        @timeout  = args[:timeout]
+        @size     = args[:size]
       end
     end
 

--- a/test/unit/connection_tests.rb
+++ b/test/unit/connection_tests.rb
@@ -7,21 +7,21 @@ require 'ostruct'
 module HellaRedis::Connection
 
   class UnitTests < Assert::Context
-    desc "a RedisConnection"
+    desc "HellaRedis::Connection"
     setup do
-      @config = OpenStruct.new({
+      @config = {
         :timeout  => 1,
         :size     => 5,
         :redis_ns => 'hella-redis-test',
         :driver   => 'ruby',
         :url      => 'redis://localhost:6379/0'
-      })
+      }
       @conn = HellaRedis::Connection.new(@config)
     end
     subject{ @conn }
 
-    should "return a connection pool" do
-      assert_kind_of ConnectionPool, subject
+    should "build a connection pool" do
+      assert_instance_of ::ConnectionPool, subject
     end
 
     should "connect to the redis instance that was provided" do
@@ -30,10 +30,19 @@ module HellaRedis::Connection
       end
     end
 
-    should "build a redis namespace and yield it using #with" do
+    should "build a redis namespace and yield it using `with`" do
       subject.with do |conn|
-        assert_kind_of Redis::Namespace, conn
+        assert_instance_of ::Redis::Namespace, conn
       end
+    end
+
+    should "allow passing a config object when building a connection" do
+      conn = nil
+      assert_nothing_raised do
+        config = OpenStruct.new(@config)
+        conn = HellaRedis::Connection.new(config)
+      end
+      assert_instance_of ::ConnectionPool, conn
     end
 
   end


### PR DESCRIPTION
This updates the `Connection` to allow passing it a hash.
Previously it just took a config object that it used to build its
connection pool and redis connection. Now if a hash is built, it
is converted to a config object and used. This way, either a
config object or a hash can be passed.

Closes #4 

@kellyredding - Ready for review.
