### PR TITLE
Add a `ConnectionSpy`

### DIFF
--- a/lib/hella-redis/connection.rb
+++ b/lib/hella-redis/connection.rb
@@ -10,7 +10,7 @@ module HellaRedis
       config = Config.new(config) if config.kind_of?(::Hash)
       ::ConnectionPool.new(:timeout => config.timeout, :size => config.size) do
         ::Redis::Namespace.new(config.redis_ns, {
-          :redis => ::Redis.connect({
+          :redis => ::Redis.new({
             :url    => config.url,
             :driver => config.driver
           })
@@ -26,7 +26,7 @@ module HellaRedis
         @driver   = args[:driver]
         @redis_ns = args[:ns]
         @timeout  = args[:timeout]
-        @size     = args[:size]
+        @size     = args[:size] || 1
       end
     end
 

--- a/lib/hella-redis/connection_spy.rb
+++ b/lib/hella-redis/connection_spy.rb
@@ -1,0 +1,54 @@
+require 'redis'
+require 'hella-redis/connection'
+
+module HellaRedis
+
+  class ConnectionSpy
+
+    attr_reader :config
+    attr_reader :with_calls, :redis_calls
+
+    def initialize(config)
+      @config      = config
+      @with_calls  = []
+      @redis_calls = []
+      @redis       = RedisSpy.new(config, @redis_calls)
+    end
+
+    def with(*args, &block)
+      @with_calls << WithCall.new(args)
+      block.call(@redis)
+    end
+
+    class RedisSpy
+      attr_reader :calls
+
+      def initialize(config, calls)
+        # mimic the real conection behavior, accept hash or object
+        config = Connection::Config.new(config) if config.kind_of?(::Hash)
+        @instance = ::Redis.new({
+          :url    => config.url,
+          :driver => config.driver
+        })
+        @calls = calls
+      end
+
+      def method_missing(name, *args, &block)
+        if self.respond_to?(name)
+          @calls << RedisCall.new(name, args, block)
+        else
+          super
+        end
+      end
+
+      def respond_to?(*args)
+        super || @instance.respond_to?(*args)
+      end
+    end
+
+    WithCall  = Struct.new(:args)
+    RedisCall = Struct.new(:command, :args, :block)
+
+  end
+
+end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -6,3 +6,5 @@ $LOAD_PATH.unshift(File.expand_path("../..", __FILE__))
 
 # require pry for debugging (`binding.pry`)
 require 'pry'
+
+require 'test/support/factory'

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -1,0 +1,6 @@
+require 'assert/factory'
+
+module Factory
+  extend Assert::Factory
+
+end

--- a/test/unit/connection_spy_tests.rb
+++ b/test/unit/connection_spy_tests.rb
@@ -1,0 +1,80 @@
+require 'assert'
+require 'hella-redis/connection_spy'
+
+class HellaRedis::ConnectionSpy
+
+  class UnitTests < Assert::Context
+    desc "HellaRedis::ConnectionSpy"
+    setup do
+      @config = {
+        :url    => 'redis://localhost:6379/0',
+        :driver => 'ruby'
+      }
+      @connection_spy = HellaRedis::ConnectionSpy.new(@config)
+    end
+    subject{ @connection_spy }
+
+    should have_readers :config, :with_calls, :redis_calls
+    should have_imeths :with
+
+    should "know its config" do
+      assert_equal @config, subject.config
+    end
+
+    should "default its calls" do
+      assert_equal [], subject.with_calls
+      assert_equal [], subject.redis_calls
+    end
+
+    should "yield a redis spy using `with`" do
+      yielded = nil
+      subject.with{ |c| yielded = c }
+      assert_instance_of RedisSpy, yielded
+      assert_same subject.redis_calls, yielded.calls
+    end
+
+    should "track calls to with" do
+      overrides = { :timeout => Factory.integer }
+      subject.with(overrides){ |c| }
+      call = subject.with_calls.last
+      assert_equal [overrides], call.args
+    end
+
+  end
+
+  class RedisSpyTests < UnitTests
+    desc "RedisSpy"
+    setup do
+      @calls = []
+      @redis_spy = RedisSpy.new(@config, @calls)
+    end
+    subject{ @redis_spy }
+
+    should have_readers :calls
+
+    should "allow passing a config object" do
+      config = OpenStruct.new(@config)
+      assert_nothing_raised{ RedisSpy.new(config, @calls) }
+    end
+
+    should "track redis calls made to it" do
+      assert_true subject.respond_to?(:set)
+
+      key, value = [Factory.string, Factory.string]
+      subject.set(key, value)
+
+      call = subject.calls.first
+      assert_equal :set, call.command
+      assert_equal [key, value], call.args
+    end
+
+    should "raise no method errors for non-redis methods" do
+      assert_false subject.respond_to?(:super_awesome_set)
+      assert_raises(NoMethodError) do
+        subject.super_awesome_set(Factory.string, Factory.string)
+      end
+    end
+
+  end
+
+end

--- a/test/unit/connection_tests.rb
+++ b/test/unit/connection_tests.rb
@@ -9,14 +9,14 @@ module HellaRedis::Connection
   class UnitTests < Assert::Context
     desc "HellaRedis::Connection"
     setup do
-      @config = {
+      @config_hash = {
         :timeout  => 1,
         :size     => 5,
         :redis_ns => 'hella-redis-test',
         :driver   => 'ruby',
         :url      => 'redis://localhost:6379/0'
       }
-      @conn = HellaRedis::Connection.new(@config)
+      @conn = HellaRedis::Connection.new(@config_hash)
     end
     subject{ @conn }
 
@@ -39,10 +39,35 @@ module HellaRedis::Connection
     should "allow passing a config object when building a connection" do
       conn = nil
       assert_nothing_raised do
-        config = OpenStruct.new(@config)
+        config = OpenStruct.new(@config_hash)
         conn = HellaRedis::Connection.new(config)
       end
       assert_instance_of ::ConnectionPool, conn
+    end
+
+  end
+
+  class ConfigTests < UnitTests
+    desc "Config"
+    setup do
+      @config = Config.new(@config_hash)
+    end
+    subject{ @config }
+
+    should have_readers :url, :driver, :redis_ns, :timeout, :size
+
+    should "know its attributes" do
+      assert_equal @config_hash[:url],     subject.url
+      assert_equal @config_hash[:driver],  subject.driver
+      assert_equal @config_hash[:ns],      subject.redis_ns
+      assert_equal @config_hash[:timeout], subject.timeout
+      assert_equal @config_hash[:size],    subject.size
+    end
+
+    should "default its size" do
+      @config_hash.delete(:size)
+      config = Config.new(@config_hash)
+      assert_equal 1, config.size
     end
 
   end


### PR DESCRIPTION
This adds a `ConnectionSpy` that can be used to replace a real
connection in tests. This allows avoiding hitting redis in a
test suite and also to inspect what calls were made and with what
args. The spy responds to the same methods as redis and will
track any calls made to those. Finally, the spy can also be used
as a base to add extended behavior for specific redis commands.

This also updates the `Connection::Config` to default its size to
1. `ConnectionPool` will error if size is `nil`. This also adds
tests for `Config` to test that it properly defaults it.

This also switches from `Redis.connect` to `Redis.new` because the
connect method has been deprecated in favor of using `new`.

@kellyredding - Ready for review.
