### PR TITLE
Make `ConnectionSpy` and `RedisSpy` easier to extend

### DIFF
--- a/lib/hella-redis/connection_spy.rb
+++ b/lib/hella-redis/connection_spy.rb
@@ -5,50 +5,54 @@ module HellaRedis
 
   class ConnectionSpy
 
-    attr_reader :config
-    attr_reader :with_calls, :redis_calls
+    attr_reader :config, :redis_spy, :with_calls
 
-    def initialize(config)
-      @config      = config
-      @with_calls  = []
-      @redis_calls = []
-      @redis       = RedisSpy.new(config, @redis_calls)
+    def initialize(config, redis_spy = nil)
+      @config     = config
+      @with_calls = []
+      @redis_spy  = redis_spy || RedisSpy.new(config)
     end
 
     def with(*args, &block)
-      @with_calls << WithCall.new(args)
-      block.call(@redis)
+      @with_calls << WithCall.new(args, block)
+      block.call(@redis_spy)
     end
 
-    class RedisSpy
-      attr_reader :calls
-
-      def initialize(config, calls)
-        # mimic the real conection behavior, accept hash or object
-        config = Connection::Config.new(config) if config.kind_of?(::Hash)
-        @instance = ::Redis.new({
-          :url    => config.url,
-          :driver => config.driver
-        })
-        @calls = calls
-      end
-
-      def method_missing(name, *args, &block)
-        if self.respond_to?(name)
-          @calls << RedisCall.new(name, args, block)
-        else
-          super
-        end
-      end
-
-      def respond_to?(*args)
-        super || @instance.respond_to?(*args)
-      end
+    def redis_calls
+      @redis_spy.calls
     end
-
-    WithCall  = Struct.new(:args)
-    RedisCall = Struct.new(:command, :args, :block)
 
   end
+
+  class RedisSpy
+
+    attr_reader :calls
+
+    def initialize(config)
+      # mimic the real conection behavior, accept hash or object
+      config = Connection::Config.new(config) if config.kind_of?(::Hash)
+      @instance = ::Redis.new({
+        :url    => config.url,
+        :driver => config.driver
+      })
+      @calls = []
+    end
+
+    def method_missing(name, *args, &block)
+      if self.respond_to?(name)
+        @calls << RedisCall.new(name, args, block)
+      else
+        super
+      end
+    end
+
+    def respond_to?(*args)
+      super || @instance.respond_to?(*args)
+    end
+
+  end
+
+  WithCall  = Struct.new(:args, :block)
+  RedisCall = Struct.new(:command, :args, :block)
 
 end

--- a/test/unit/connection_spy_tests.rb
+++ b/test/unit/connection_spy_tests.rb
@@ -14,47 +14,61 @@ class HellaRedis::ConnectionSpy
     end
     subject{ @connection_spy }
 
-    should have_readers :config, :with_calls, :redis_calls
-    should have_imeths :with
+    should have_readers :config, :redis_spy, :with_calls
+    should have_imeths :with, :redis_calls
 
-    should "know its config" do
+    should "know its config and redis spy" do
       assert_equal @config, subject.config
+      assert_instance_of HellaRedis::RedisSpy, subject.redis_spy
     end
 
-    should "default its calls" do
+    should "default its with calls" do
       assert_equal [], subject.with_calls
-      assert_equal [], subject.redis_calls
     end
 
-    should "yield a redis spy using `with`" do
+    should "know its redis spy's calls" do
+      assert_same subject.redis_spy.calls, subject.redis_calls
+    end
+
+    should "yield its redis spy using `with`" do
       yielded = nil
       subject.with{ |c| yielded = c }
-      assert_instance_of RedisSpy, yielded
-      assert_same subject.redis_calls, yielded.calls
+      assert_same subject.redis_spy, yielded
     end
 
     should "track calls to with" do
       overrides = { :timeout => Factory.integer }
-      subject.with(overrides){ |c| }
+      block = proc{ |c| Factory.string }
+      subject.with(overrides, &block)
       call = subject.with_calls.last
       assert_equal [overrides], call.args
+      assert_equal block, call.block
+    end
+
+    should "allow passing a custom redis spy" do
+      redis_spy = Factory.string
+      spy = HellaRedis::ConnectionSpy.new(@config, redis_spy)
+      assert_equal redis_spy, spy.redis_spy
     end
 
   end
 
   class RedisSpyTests < UnitTests
-    desc "RedisSpy"
+    desc "HellaRedis::RedisSpy"
     setup do
-      @calls = []
-      @redis_spy = RedisSpy.new(@config, @calls)
+      @redis_spy = HellaRedis::RedisSpy.new(@config)
     end
     subject{ @redis_spy }
 
     should have_readers :calls
 
+    should "default its calls" do
+      assert_equal [], subject.calls
+    end
+
     should "allow passing a config object" do
       config = OpenStruct.new(@config)
-      assert_nothing_raised{ RedisSpy.new(config, @calls) }
+      assert_nothing_raised{ HellaRedis::RedisSpy.new(config) }
     end
 
     should "track redis calls made to it" do


### PR DESCRIPTION
This updates the `ConnectionSpy` and `RedisSpy` that it uses and
makes them easier to extend. This simplifies their interfaces and
makes it so a redis spy can be optionally passed in. This allows
creating a custom redis spy and using that with a connection spy.
This also moves the `RedisSpy` out from under the `ConnectionSpy`
so it is simpler to inherit from. All of this makes the spy more
usable as a base that can be extended with custom behavior.

@kellyredding - Ready for review. Most of the diff is changing the indention of the `RedisSpy` since it is no longer under `ConnectionSpy`. The only thing that changed with the `RedisSpy` is it is no longer passed calls.
