### PR TITLE
Update `ConnectionSpy`, handle `pipelined` and `multi`

### DIFF
--- a/lib/hella-redis/connection_spy.rb
+++ b/lib/hella-redis/connection_spy.rb
@@ -38,6 +38,16 @@ module HellaRedis
       @calls = []
     end
 
+    def pipelined
+      @calls << RedisCall.new(:pipelined, [])
+      yield self
+    end
+
+    def multi
+      @calls << RedisCall.new(:multi, [])
+      yield self
+    end
+
     def method_missing(name, *args, &block)
       if self.respond_to?(name)
         @calls << RedisCall.new(name, args, block)

--- a/test/unit/connection_spy_tests.rb
+++ b/test/unit/connection_spy_tests.rb
@@ -66,7 +66,7 @@ class HellaRedis::ConnectionSpy
     end
     subject{ @redis_spy }
 
-    should have_readers :calls
+    should have_readers :pipelined, :multi, :calls
 
     should "default its calls" do
       assert_equal [], subject.calls
@@ -86,6 +86,16 @@ class HellaRedis::ConnectionSpy
       call = subject.calls.first
       assert_equal :set, call.command
       assert_equal [key, value], call.args
+    end
+
+    should "track the call and yield itself using `pipelined`" do
+      subject.pipelined{ |c| c.set(Factory.string, Factory.string) }
+      assert_equal [:pipelined, :set], subject.calls.map(&:command)
+    end
+
+    should "track the call and yield itself using `multi`" do
+      subject.multi{ |c| c.set(Factory.string, Factory.string) }
+      assert_equal [:multi, :set], subject.calls.map(&:command)
     end
 
     should "raise no method errors for non-redis methods" do


### PR DESCRIPTION
This updates the `ConnectionSpy` to handle `pipelined` and `multi`
redis calls separately from all other redis calls. They will now
yield to the block passed to them which allows any redis calls
done in the block to automatically be spied as expected. This
makes it so the blocks do not have to manually called.

The `pipelined` and `multi` commands are special commands that
take a block in ruby. The `pipelined` command is for sending lots
of commands in a single request to the redis server. The benefit
is not paying the overhead of a round trip for each command. The
`multi` command is for running transactions in redis. The spy now
tracks the `pipelined` or `multi` call and then yields itself.
This makes it so a test can easily see that pipelining or a
transaction was used with a set of commands.

@kellyredding - Ready for review. I'm using this for testing Qs subscriptions logic.