### PR TITLE
add `reset!` method to connection pool spy

### DIFF
--- a/lib/hella-redis/connection_pool_spy.rb
+++ b/lib/hella-redis/connection_pool_spy.rb
@@ -23,6 +23,11 @@ module HellaRedis
       block.call(@connection_spy)
     end
 
+    def reset!
+      @connection_calls     = []
+      @connection_spy.calls = []
+    end
+
     ConnectionCall = Struct.new(:block)
 
   end

--- a/lib/hella-redis/connection_spy.rb
+++ b/lib/hella-redis/connection_spy.rb
@@ -4,7 +4,7 @@ module HellaRedis
 
   class ConnectionSpy
 
-    attr_reader :calls
+    attr_accessor :calls
 
     def initialize(config)
       @instance = ::Redis.new({

--- a/test/unit/connection_pool_spy_tests.rb
+++ b/test/unit/connection_pool_spy_tests.rb
@@ -19,7 +19,7 @@ class HellaRedis::ConnectionPoolSpy
     subject{ @connection_pool_spy }
 
     should have_readers :config, :connection_spy, :connection_calls
-    should have_imeths :calls, :connection
+    should have_imeths :calls, :connection, :reset!
 
     should "know its config and redis spy" do
       assert_equal @config, subject.config
@@ -49,6 +49,18 @@ class HellaRedis::ConnectionPoolSpy
 
       call = subject.connection_calls.last
       assert_equal block, call.block
+    end
+
+    should "remove all calls on `reset!`" do
+      subject.connection{ |c| c.info }
+
+      assert_not_empty subject.calls
+      assert_not_empty subject.connection_calls
+
+      subject.reset!
+
+      assert_empty subject.calls
+      assert_empty subject.connection_calls
     end
 
   end

--- a/test/unit/connection_spy_tests.rb
+++ b/test/unit/connection_spy_tests.rb
@@ -10,7 +10,7 @@ class HellaRedis::ConnectionSpy
     end
     subject{ @connection_spy }
 
-    should have_readers :calls
+    should have_accessors :calls
     should have_imeths :pipelined, :multi
 
     should "default its calls" do


### PR DESCRIPTION
This allows clearing out all of the calls on a pool spy.  This is
handy to do in test setup/teardown so that call state from one
test doesn't interfere with other tests.

I chose to make the `calls` method on the connection spy an
accessor so I could manually empty it instead of making a `reset!`
method on the connection spy.  I didn't want to add another method
to the connection spy since it uses method missing to proxy the
redis instance.  I didn't want to pollute the method-space or add
possibilities for method collisions with the instance.

@jcredding ready for review.