### PR TITLE
make ConnectionPoolSpy know if it is equal to another pool spy

### DIFF
--- a/lib/hella-redis/connection_pool_spy.rb
+++ b/lib/hella-redis/connection_pool_spy.rb
@@ -28,6 +28,12 @@ module HellaRedis
       @connection_spy.calls = []
     end
 
+    def ==(other_pool_spy)
+      if other_pool_spy.kind_of?(ConnectionPoolSpy)
+        self.config == other_pool_spy.config
+      end
+    end
+
     ConnectionCall = Struct.new(:block)
 
   end

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -9,9 +9,9 @@ module Factory
   end
 
   def self.config_args(args = nil)
-    { :timeout  => 1,
-      :size     => 5,
-      :redis_ns => 'hella-redis-test',
+    { :timeout  => Factory.integer,
+      :size     => Factory.integer(5),
+      :redis_ns => "hella-redis-test-#{Factory.string}",
       :url      => 'redis://localhost:6379/0',
       :driver   => 'ruby'
     }.merge(args || {})

--- a/test/unit/connection_pool_spy_tests.rb
+++ b/test/unit/connection_pool_spy_tests.rb
@@ -63,6 +63,14 @@ class HellaRedis::ConnectionPoolSpy
       assert_empty subject.connection_calls
     end
 
+    should "know if it is equal to another pool spy" do
+      equal_pool_spy = HellaRedis::ConnectionPoolSpy.new(@config)
+      assert_equal subject, equal_pool_spy
+
+      not_equal_config = HellaRedis::ConnectionPoolSpy.new(Factory.config)
+      assert_not_equal subject, not_equal_config
+    end
+
   end
 
 end


### PR DESCRIPTION
This is to ease testing how HellaRedis is configured.  We shouldn't
make the dev know to create a Config from the hash they passed
configuring HellaRedis and compare that to their config.

This is just a minor test UX improvement.

@jcredding ready for review.