### PR TITLE
add `real` and `mock`  methods for building specific connection pools

### DIFF
--- a/lib/hella-redis.rb
+++ b/lib/hella-redis.rb
@@ -5,9 +5,15 @@ require 'hella-redis/connection_pool_spy'
 module HellaRedis
 
   def self.new(args)
-    (ENV['HELLA_REDIS_TEST_MODE'] ? ConnectionPoolSpy : ConnectionPool).new(
-      Config.new(args)
-    )
+    self.send(ENV['HELLA_REDIS_TEST_MODE'] ? :mock : :real, args)
+  end
+
+  def self.real(args)
+    ConnectionPool.new(Config.new(args))
+  end
+
+  def self.mock(args)
+    ConnectionPoolSpy.new(Config.new(args))
   end
 
   class Config


### PR DESCRIPTION
There are times when you want to build a ConnectionPoolSpy as
easily as you would calling `new` but don't want to put HellaRedis
in test mode.  This allows for that scenario - you can now call`
`mock` instead of `new`.

The `real` method was added to compliment `mock` and to bypass
any test mode handling.

With these two methods, users can manually manage test mode
without having to put HellaRedis into test mode if desired.

@jcredding ready for review.